### PR TITLE
[Feature] GZip Middleware 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,14 @@
 from PIL import Image
 import io
-from services.inside_return_featuremap import process_image, feature_maps, fc, convert_list, get_normalized_outputs
+from services.inside_return_featuremap import process_image, feature_maps, fc, get_normalized_outputs
 
 from fastapi import FastAPI, File, UploadFile
+from fastapi.middleware.gzip import GZipMiddleware
 from typing import List
 
 app = FastAPI()
+
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 # 행렬 구조 반환 API
 # 각 레이어에 대한 행렬 값 제공


### PR DESCRIPTION
## 연관된 이슈

> #7 

## 작업 내용

- GZip 미들웨어 등록 1KB 넘는 응답 데이터에 대해서 압축 적용
- 용량 8.73MB -> 1.02MB로 유의미하게 감소

<img width="1715" height="1526" alt="compressed_data" src="https://github.com/user-attachments/assets/f1847acc-8050-4e74-9ab3-f3e4970a9139" />
