### PR TITLE
[feat]piano 엔드포인트 설정 & mp3 to MIDI 코드 추가 & requirements.txt 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,3 +27,11 @@ async def upload_inside_image(num_image: UploadFile = File(...)):
     pil_img = Image.open(io.BytesIO(contents))
     result = get_normalized_outputs(pil_img)   # 새 이미지로 계산
     return result
+
+@app.get("/api/piano/")
+def get_MIDI():
+    return {"message": "아직 구현되지 않음"}
+
+@app.post("/api/piano/")
+async def upload_MIDI(file: UploadFile = File(...)):
+    return {"message": "아직 구현되지 않음"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+#--------------- inside ---------------
 annotated-types==0.7.0
 anyio==4.10.0
 contourpy==1.3.2
@@ -32,3 +33,38 @@ typing_extensions==4.15.0
 uvicorn==0.35.0
 torchvision==0.23.0
 python-multipart==0.0.20
+
+#--------------- piano ---------------
+audioop-lts==0.2.2
+audioread==3.0.1
+certifi==2025.8.3
+cffi==2.0.0
+charset-normalizer==3.4.3
+decorator==5.2.1
+idna==3.10
+joblib==1.5.2
+lazy_loader==0.4
+librosa==0.11.0
+llvmlite==0.45.1
+mido==1.3.3
+msgpack==1.1.1
+numba==0.62.1
+#넘피 중복
+packaging==25.0
+platformdirs==4.4.0
+pooch==1.8.2
+pretty_midi==0.2.10
+pycparser==2.23
+requests==2.32.5
+scikit-learn==1.7.2
+scipy==1.16.2
+setuptools==80.9.0
+six==1.17.0
+soundfile==0.13.1
+soxr==1.0.0
+standard-aifc==3.13.0
+standard-chunk==3.13.0
+standard-sunau==3.13.0
+threadpoolctl==3.6.0
+typing_extensions==4.15.0
+urllib3==2.5.0

--- a/services/p!ano.py
+++ b/services/p!ano.py
@@ -1,0 +1,90 @@
+# ----------------------------------------------------------
+# p!ano
+# Mac OS에서 GarageBand나 Logic을 이용해서 test 가능
+# ----------------------------------------------------------
+import numpy as np
+import librosa
+import pretty_midi
+import json
+
+def freq_to_midi(freq: int) -> int:
+    """
+        주파수를 MIDI 노트로 변환하는 함수
+
+    Args:
+        freq (int): frequency value
+
+    Returns:
+        int: MIDI
+        
+    Example:
+        -----------------------------
+        Frequency → MIDI Note 변환 공식
+        -----------------------------
+        MIDI = 69 + 12 x log2(f / 440)
+        f = 440 Hz → MIDI = 69
+        f = 880 Hz → MIDI = 81
+        f = 220 Hz → MIDI = 57
+        -----------------------------
+    """
+    return int(np.round(69 + 12 * np.log2(freq / 440.0)))
+
+
+def talking_piano(config_path):
+    # ----------------------------------------------------------
+    # 설정
+    # ----------------------------------------------------------
+    with open(config_path, "r") as config_path:
+        configs = json.load(config_path)
+    mp3_path = configs["mp3_path"]
+    output_midi_path = configs["output_midi_path"]
+    n_fft = configs["n_fft"]
+    hop_length = configs["hop_length"]
+    velocity = configs["velocity"]
+    threshold_ratio = configs["threshold_ratio"]
+    note_duration = configs["note_duration"]
+
+    # ----------------------------------------------------------
+    # 1. MP3 로드
+    # ----------------------------------------------------------
+    y, sr = librosa.load(mp3_path, sr=44100, mono=True)
+
+    # ----------------------------------------------------------
+    # 2. STFT(Short-time Fourier transform) 계산
+    # ----------------------------------------------------------
+    D = np.abs(librosa.stft(y, n_fft=n_fft, hop_length=hop_length))
+    frequencies = librosa.fft_frequencies(sr=sr, n_fft=n_fft)
+    times = librosa.frames_to_time(np.arange(D.shape[1]), sr=sr, hop_length=hop_length)
+
+    # ----------------------------------------------------------
+    # 3. MIDI 생성 및 frequency 매핑
+    # ----------------------------------------------------------
+    midi = pretty_midi.PrettyMIDI()
+    piano = pretty_midi.Instrument(program=0)
+
+    # thrashold는 특정 값 이하면 무시함 너무 많은 건반이 눌리는 것을 방지함
+    threshold = threshold_ratio * np.max(D) 
+
+    for t_idx, t in enumerate(times):
+        for f_idx, f in enumerate(frequencies):
+            if D[f_idx, t_idx] > threshold:
+                note_number = freq_to_midi(f)
+                # MIDI 범위 0~127 제한
+                # MIDI에서는 음 높이(pitch) 가 0부터 127까지만 허용됨
+                if 0 <= note_number <= 127:
+                    note = pretty_midi.Note(
+                        velocity=velocity,
+                        pitch=note_number,
+                        start=t,
+                        end=t + note_duration
+                    )
+                    piano.notes.append(note)
+
+    midi.instruments.append(piano)
+    midi.write(output_midi_path)
+
+    print(f"MIDI 생성 완료: {output_midi_path}")
+
+if __name__ == "__main__":
+    configs = "config.json"
+    talking_piano(configs)


### PR DESCRIPTION
piano 엔드포인트 구현
p!ano.py(mp3 to MIDI 변환 파일)을 services폴더 안에 추가
requirements.txt에 piano 도 추가했습니다. (inside랑 겹치는 numpy는 inside에서 사용한 2.2.6만 남겨두고 piano에서는 지웠습니다.)
